### PR TITLE
add an Emacs lsp-mode usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ Install tagls by `pip3 install tagls` and register it in your code editor. For e
   }
 ```
 
+Or if you use Emacs `lsp-mode`:
+
+```emacs-lisp
+  (lsp-register-client
+   (make-lsp-client :new-connection
+                    (lsp-stdio-connection '("python3" "-m" "tagls"))
+                    :server-id 'tagls
+                    :activation-fn (lsp-activate-on "c" "cpp" "python")
+                    ;; provide initialization options:
+                    ;;   :initialization-options '((cache_dir . "/tmp/gtags"))
+                    ))
+```
+
 #### Custom LSP methods
 
 Tagls provides custom LSP methods beginning with `$tagls/`, so if you want, you can keep tagls from registering official LSP methods and communicate with tagls only by these custom methods. For example, if you want to **use tagls only when all other languages servers cannot give any results**, you can set `register_official_methods` to `[]` (also see above section), and add the following lines in your .vimrc (also see the following "NOTE"):

--- a/tagls/server.py
+++ b/tagls/server.py
@@ -282,11 +282,12 @@ async def initialize(ls: LanguageServer, params: types.InitializeParams):
     result = builtin_initialize(ls.lsp, params)
     root_path = ls.workspace.root_path
     assert root_path is not None
+    init_options: Dict[str, Any] = {}
     if isinstance(params.initialization_options, dict):
-        init_options: Dict[str, Any] = params.initialization_options
-        show_message_log(f"initialization_options: {init_options}")
+        init_options = params.initialization_options
+        show_message_log(f"Initialization_options: {init_options}")
     else:
-        raise ValueError(f"Wrong initialization_options {params.initialization_options}")
+        show_message_log(f"No initialization_options found, using default values")
     global gtags_provider
     gtags_provider = init_options.get("gtags_provider", "tagls")
     show_message_log(f"gtags_provider: {gtags_provider}")
@@ -319,5 +320,5 @@ async def initialize(ls: LanguageServer, params: types.InitializeParams):
 
 @server.feature(INITIALIZED)
 def initialized(ls: LanguageServer, params: types.InitializedParams):
-    show_message_log("initialized")
+    show_message_log("Initialized")
 


### PR DESCRIPTION
Hi daquexian,

This pull request contains my experience in using tagls as a language server in Emacs (specifically, with Emacs [lsp-mode](https://github.com/emacs-lsp/lsp-mode)).  When I tried, I found that lsp-mode does not send initializationOptions if `:initialization-options` is not specified when registering the language server.  In this case, tagls got `None` as params.initialization_options and raised ValueError and server initialization failed.

So I replace the `raise` with an empty dict when client does not provide initializationOptions, so that default values are used, and the initialization proceed.  Do you think it is OK?

Also, a configuration example for Emacs lsp-mode is added to README.md (tested in my environment, Emacs 28.1, lsp-mode 480f804c1).  I may also take some responsibility to maintain this part later, if you will :)

Fan

P.S. I was looking for a tag-based lsp server then I found tagls which suits my need well. So thanks for this project, sincerely <3